### PR TITLE
feat: Add automatic host user mapping for Docker environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,50 @@ tasks:
 - **Unix/macOS**: bash with `-c` args
 - **Windows**: cmd with `/c` args
 
+### Docker Environments
+
+Execute tasks inside Docker containers for reproducible builds and isolated execution:
+
+```yaml
+environments:
+  builder:
+    dockerfile: build.dockerfile
+    context: .
+    volumes:
+      - .:/workspace
+    working_dir: /workspace
+
+tasks:
+  build:
+    env: builder
+    cmd: cargo build --release
+```
+
+#### User Mapping
+
+By default, tasks run inside Docker containers execute as your current host user (UID:GID) rather than root. This ensures files created in mounted volumes have correct ownership on the host filesystem.
+
+To run as root inside the container (e.g., for package installation or privileged operations), set `run_as_root: true`:
+
+```yaml
+environments:
+  privileged:
+    dockerfile: admin.dockerfile
+    context: .
+    run_as_root: true
+    volumes:
+      - .:/workspace
+```
+
+**Note**: On Windows, user mapping is handled automatically by Docker Desktop and this setting has no effect.
+
+#### Use Cases for `run_as_root: true`
+
+You may need to set `run_as_root: true` when:
+- Container process needs to bind to privileged ports (<1024)
+- Installing packages during task execution
+- Software explicitly requires root privileges
+
 ### Parameterised Tasks
 
 Tasks can accept arguments with optional defaults:

--- a/src/tasktree/parser.py
+++ b/src/tasktree/parser.py
@@ -37,6 +37,7 @@ class Environment:
     env_vars: dict[str, str] = field(default_factory=dict)  # Environment variables
     working_dir: str = ""  # Working directory (container or host)
     extra_args: List[str] = field(default_factory=list) # Any extra arguments to pass to docker
+    run_as_root: bool = False  # If True, skip user mapping (run as root in container)
 
     def __post_init__(self):
         """Ensure args is always a list."""
@@ -664,6 +665,7 @@ def _parse_file_with_env(
                     ports = env_config.get("ports", [])
                     env_vars = env_config.get("env_vars", {})
                     extra_args = env_config.get("extra_args", [])
+                    run_as_root = env_config.get("run_as_root", False)
 
                     # Validate environment type
                     if not shell and not dockerfile:
@@ -717,7 +719,8 @@ def _parse_file_with_env(
                         ports=ports,
                         env_vars=env_vars,
                         working_dir=working_dir,
-                        extra_args=extra_args
+                        extra_args=extra_args,
+                        run_as_root=run_as_root
                     )
 
     return tasks, environments, default_env, variables


### PR DESCRIPTION
This PR implements automatic user mapping for Docker containers to ensure files created in mounted volumes have correct ownership on the host filesystem.

## Changes
- Added `run_as_root` optional field to Environment configuration
- Docker tasks now run as current host user by default on Linux/macOS
- Windows skips user mapping (handled by Docker Desktop)
- Users can opt out with `run_as_root: true`
- Comprehensive tests and documentation included

Resolves #12

🤖 Generated with [Claude Code](https://claude.ai/code)