### PR TITLE
feat: Convert task argument syntax to pure YAML

### DIFF
--- a/src/tasktree/__init__.py
+++ b/src/tasktree/__init__.py
@@ -16,7 +16,7 @@ from tasktree.graph import (
     resolve_execution_order,
 )
 from tasktree.hasher import hash_args, hash_task, make_cache_key
-from tasktree.parser import Recipe, Task, find_recipe_file, parse_arg_spec, parse_recipe
+from tasktree.parser import ArgSpec, Recipe, Task, find_recipe_file, parse_args_yaml, parse_recipe
 from tasktree.state import StateManager, TaskState
 
 __all__ = [
@@ -32,10 +32,11 @@ __all__ = [
     "hash_args",
     "hash_task",
     "make_cache_key",
+    "ArgSpec",
     "Recipe",
     "Task",
     "find_recipe_file",
-    "parse_arg_spec",
+    "parse_args_yaml",
     "parse_recipe",
     "StateManager",
     "TaskState",

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -35,7 +35,11 @@ class TestEndToEnd(unittest.TestCase):
             recipe_file.write_text("""
 tasks:
   deploy:
-    args: [environment, region:str=us-west-1, port:int=8080, debug:bool=false]
+    args:
+      - environment
+      - region: {type: str, default: us-west-1}
+      - port: {type: int, default: 8080}
+      - debug: {type: bool, default: false}
     outputs: [deploy.log]
     cmd: echo "env={{ arg.environment }} region={{ arg.region }} port={{ arg.port }} debug={{ arg.debug }}" > deploy.log
 """)

--- a/tests/integration/test_state_persistence.py
+++ b/tests/integration/test_state_persistence.py
@@ -93,7 +93,8 @@ tasks:
             recipe_file.write_text("""
 tasks:
   deploy:
-    args: [environment]
+    args:
+      - environment
     outputs: ["deploy-{{ arg.environment }}.log"]
     cmd: echo "Deployed to {{ arg.environment }}" > deploy-{{ arg.environment }}.log
 """)

--- a/tests/integration/test_variables.py
+++ b/tests/integration/test_variables.py
@@ -64,7 +64,8 @@ variables:
 
 tasks:
   deploy:
-    args: [app_name]
+    args:
+      - app_name
     outputs: ["deploy-{{ arg.app_name }}.log"]
     cmd: echo "Deploy {{ arg.app_name }} to {{ var.server }}:{{ var.port }}" > deploy-{{ arg.app_name }}.log
 """)
@@ -458,7 +459,8 @@ variables:
 
 tasks:
   deploy:
-    args: [app_name]
+    args:
+      - app_name
     outputs: ["deploy.log"]
     cmd: echo "Deploy {{ arg.app_name }} to {{ var.server }} as {{ env.USER }}" > deploy.log
 """)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import typer
 
 from tasktree.cli import _parse_task_args
+from tasktree.parser import ArgSpec
 
 
 class TestParseTaskArgs(unittest.TestCase):
@@ -13,7 +14,10 @@ class TestParseTaskArgs(unittest.TestCase):
 
     def test_parse_task_args_positional(self):
         """Test parsing positional arguments."""
-        arg_specs = ["environment", "region"]
+        arg_specs = [
+            ArgSpec(name="environment", type="str", default=None),
+            ArgSpec(name="region", type="str", default=None),
+        ]
         arg_values = ["production", "us-east-1"]
 
         result = _parse_task_args(arg_specs, arg_values)
@@ -22,7 +26,10 @@ class TestParseTaskArgs(unittest.TestCase):
 
     def test_parse_task_args_named(self):
         """Test parsing name=value arguments."""
-        arg_specs = ["environment", "region"]
+        arg_specs = [
+            ArgSpec(name="environment", type="str", default=None),
+            ArgSpec(name="region", type="str", default=None),
+        ]
         arg_values = ["environment=production", "region=us-east-1"]
 
         result = _parse_task_args(arg_specs, arg_values)
@@ -31,7 +38,10 @@ class TestParseTaskArgs(unittest.TestCase):
 
     def test_parse_task_args_with_defaults(self):
         """Test default values applied."""
-        arg_specs = ["environment", "region=us-west-1"]
+        arg_specs = [
+            ArgSpec(name="environment", type="str", default=None),
+            ArgSpec(name="region", type="str", default="us-west-1"),
+        ]
         arg_values = ["production"]  # Only provide first arg
 
         result = _parse_task_args(arg_specs, arg_values)
@@ -40,7 +50,11 @@ class TestParseTaskArgs(unittest.TestCase):
 
     def test_parse_task_args_type_conversion(self):
         """Test values converted to correct types."""
-        arg_specs = ["port:int", "debug:bool", "timeout:float"]
+        arg_specs = [
+            ArgSpec(name="port", type="int", default=None),
+            ArgSpec(name="debug", type="bool", default=None),
+            ArgSpec(name="timeout", type="float", default=None),
+        ]
         arg_values = ["8080", "true", "30.5"]
 
         result = _parse_task_args(arg_specs, arg_values)
@@ -52,7 +66,7 @@ class TestParseTaskArgs(unittest.TestCase):
 
     def test_parse_task_args_unknown_argument(self):
         """Test error for unknown argument name."""
-        arg_specs = ["environment"]
+        arg_specs = [ArgSpec(name="environment", type="str", default=None)]
         arg_values = ["unknown_arg=value"]
 
         with self.assertRaises(typer.Exit):
@@ -60,7 +74,7 @@ class TestParseTaskArgs(unittest.TestCase):
 
     def test_parse_task_args_too_many(self):
         """Test error for too many positional args."""
-        arg_specs = ["environment"]
+        arg_specs = [ArgSpec(name="environment", type="str", default=None)]
         arg_values = ["production", "extra_value"]
 
         with self.assertRaises(typer.Exit):
@@ -68,7 +82,10 @@ class TestParseTaskArgs(unittest.TestCase):
 
     def test_parse_task_args_missing_required(self):
         """Test error for missing required argument."""
-        arg_specs = ["environment", "region"]
+        arg_specs = [
+            ArgSpec(name="environment", type="str", default=None),
+            ArgSpec(name="region", type="str", default=None),
+        ]
         arg_values = ["production"]  # Missing 'region'
 
         with self.assertRaises(typer.Exit):
@@ -76,7 +93,7 @@ class TestParseTaskArgs(unittest.TestCase):
 
     def test_parse_task_args_invalid_type(self):
         """Test error for invalid type conversion."""
-        arg_specs = ["port:int"]
+        arg_specs = [ArgSpec(name="port", type="int", default=None)]
         arg_values = ["not_a_number"]
 
         with self.assertRaises(typer.Exit):
@@ -93,7 +110,11 @@ class TestParseTaskArgs(unittest.TestCase):
 
     def test_parse_task_args_mixed(self):
         """Test mixing positional and named arguments."""
-        arg_specs = ["environment", "region", "verbose:bool"]
+        arg_specs = [
+            ArgSpec(name="environment", type="str", default=None),
+            ArgSpec(name="region", type="str", default=None),
+            ArgSpec(name="verbose", type="bool", default=None),
+        ]
         arg_values = ["production", "region=us-east-1", "verbose=true"]
 
         result = _parse_task_args(arg_specs, arg_values)


### PR DESCRIPTION
Replace custom string-based argument syntax with declarative YAML structures.

## Changes
- Added ArgSpec dataclass for structured argument specifications
- Implemented parse_args_yaml() with type inference from defaults
- Updated Task.args to use list[ArgSpec] instead of list[str]
- Updated CLI argument parsing to work with ArgSpec objects
- Removed parse_arg_spec() function and string parsing logic
- Updated all tests to use new YAML syntax
- Updated README documentation with new examples

## Breaking Change
Task definitions must update args format from:
```yaml
args: [name, key:type=default]
```
To:
```yaml
args:
  - name
  - key: {type: type, default: default}
```

Closes #7

Generated with [Claude Code](https://claude.ai/code)