### PR TITLE
Restrict task args to list syntax only

### DIFF
--- a/src/tasktree/parser.py
+++ b/src/tasktree/parser.py
@@ -60,7 +60,7 @@ class Task:
     inputs: list[str] = field(default_factory=list)
     outputs: list[str] = field(default_factory=list)
     working_dir: str = ""
-    args: list[str] = field(default_factory=list)
+    args: list[str | dict[str, Any]] = field(default_factory=list)  # Can be strings or dicts (each dict has single key: arg name)
     source_file: str = ""  # Track which file defined this task
     env: str = ""  # Environment name to use for execution
 
@@ -74,6 +74,19 @@ class Task:
             self.outputs = [self.outputs]
         if isinstance(self.args, str):
             self.args = [self.args]
+
+        # Validate args is not a dict (common YAML mistake)
+        if isinstance(self.args, dict):
+            raise ValueError(
+                f"Task '{self.name}' has invalid 'args' syntax.\n\n"
+                f"Found dictionary syntax (without dashes):\n"
+                f"  args:\n"
+                f"    {list(self.args.keys())[0] if self.args else 'key'}: ...\n\n"
+                f"Correct syntax uses list format (with dashes):\n"
+                f"  args:\n"
+                f"    - {list(self.args.keys())[0] if self.args else 'key'}: ...\n\n"
+                f"Arguments must be defined as a list, not a dictionary."
+            )
 
 
 @dataclass


### PR DESCRIPTION
Validate that task args must be defined using list syntax (with dashes) and reject dictionary syntax which caused unexpected behavior.

- Updated Task.args type hint to list[str | dict[str, Any]]
- Added validation in Task.__post_init__() to reject dict syntax
- Added comprehensive test coverage for args validation
- All 563 tests pass

Fixes #32

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/kevinchannon/tasktree/tree/claude/issue-32-20260103-0957) | [View job run](https://github.com/kevinchannon/tasktree/actions/runs/20675711804