### PR TITLE
Remove all custom argument syntax, require pure YAML

### DIFF
--- a/schema/tasktree-schema.json
+++ b/schema/tasktree-schema.json
@@ -157,16 +157,16 @@
               "description": "Directory to execute the command in (relative to recipe file)"
             },
             "args": {
-              "description": "Parameterized arguments for the task (format: name, name:type, name:type=default)",
+              "description": "Parameterized arguments for the task. Use pure YAML dictionary format: { name: { type: int, default: 42 } }",
               "oneOf": [
                 {
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "type": "object"
                   }
                 },
                 {
-                  "type": "string"
+                  "type": "object"
                 }
               ]
             },

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -35,7 +35,11 @@ class TestEndToEnd(unittest.TestCase):
             recipe_file.write_text("""
 tasks:
   deploy:
-    args: [environment, region:str=us-west-1, port:int=8080, debug:bool=false]
+    args:
+      - environment: {}
+      - region: {type: str, default: us-west-1}
+      - port: {type: int, default: 8080}
+      - debug: {type: bool, default: false}
     outputs: [deploy.log]
     cmd: echo "env={{ arg.environment }} region={{ arg.region }} port={{ arg.port }} debug={{ arg.debug }}" > deploy.log
 """)

--- a/tests/integration/test_parameterized_dependencies.yaml
+++ b/tests/integration/test_parameterized_dependencies.yaml
@@ -1,8 +1,8 @@
 tasks:
   task_parameterized:
     args:
-      - mode=debug
-      - verbose=false
+      - mode: {default: debug}
+      - verbose: {type: bool, default: false}
     cmd: echo "mode={{arg.mode}} verbose={{arg.verbose}}"
 
   task_consumer_implicit:

--- a/tests/integration/test_parameterized_deps_execution.py
+++ b/tests/integration/test_parameterized_deps_execution.py
@@ -37,8 +37,8 @@ class TestParameterizedDependencyExecution(unittest.TestCase):
 tasks:
   build:
     args:
-      - mode=debug
-      - optimize:bool=false
+      - mode: {default: debug}
+      - optimize: {type: bool, default: false}
     outputs:
       - "build-{{arg.mode}}.log"
     cmd: echo "Building {{arg.mode}} optimize={{arg.optimize}}" > build-{{arg.mode}}.log
@@ -151,8 +151,8 @@ tasks:
 tasks:
   generate:
     args:
-      - format=json
-      - pretty:bool=false
+      - format: {default: json}
+      - pretty: {type: bool, default: false}
     outputs:
       - "data.{{arg.format}}"
     cmd: echo "{{arg.format}},pretty={{arg.pretty}}" > data.{{arg.format}}


### PR DESCRIPTION
This PR removes all custom string-based argument syntax parsing. Only pure YAML dictionary format is now supported.

## Changes

**Removed syntax (no longer supported):**
- Simple strings: `argname`
- Strings with defaults: `argname=value`
- Strings with types: `argname:type`
- Strings with both: `argname:type=value`

**Required syntax (pure YAML):**
- Simple: `{ argname: {} }`
- With default: `{ argname: { default: value } }`
- With type: `{ argname: { type: int, default: 42 } }`
- Exported: `{ $argname: {} }`

**Benefits:**
- Eliminates ~50 lines of complex custom parsing code
- All parsing done via `yaml.safe_load`
- Schema validation handles more work
- More consistent and maintainable syntax
- Clear error messages for migration

**Files changed:** 6 files, 140 insertions( ), 147 deletions(-)

Fixes #35

Generated with [Claude Code](https://claude.ai/code)