### PR TITLE
Add terminal-aware symbol functions for Unicode compatibility

### DIFF
--- a/src/tasktree/cli.py
+++ b/src/tasktree/cli.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import platform
+import os
 import sys
 from pathlib import Path
 from typing import Any, List, Optional
@@ -34,16 +34,20 @@ def _supports_unicode() -> bool:
     Returns:
         True if terminal supports UTF-8, False otherwise
     """
-    # Check if stdout encoding supports UTF-8
-    encoding = getattr(sys.stdout, 'encoding', None)
-    if encoding:
-        # Normalize encoding name: remove hyphens and underscores, convert to lowercase
-        normalized = encoding.lower().replace('-', '').replace('_', '')
-        if normalized.startswith('utf8'):
-            return True
+    # Hard stop: classic Windows console (conhost)
+    if os.name == "nt" and "WT_SESSION" not in os.environ:
+        return False
 
-    # If no UTF-8 detected, default to ASCII for safety
-    return False
+    # Encoding check
+    encoding = sys.stdout.encoding
+    if not encoding:
+        return False
+
+    try:
+        "✓✗".encode(encoding)
+        return True
+    except UnicodeEncodeError:
+        return False
 
 
 def get_action_success_string() -> str:


### PR DESCRIPTION
Fixes #47

### Changes

- Created `get_action_success_string()` and `get_action_failure_string()`
- Functions detect terminal UTF-8 encoding support
- Fall back to platform detection (Windows check) if encoding unavailable
- Replaced hardcoded Unicode symbols with function calls
- Maintains Unicode symbols on capable terminals, ASCII on Windows cmd

Generated with [Claude Code](https://claude.ai/code)