### PR TITLE
Phase 2: Remove old execution methods and simplify environment resolution

### DIFF
--- a/src/tasktree/executor.py
+++ b/src/tasktree/executor.py
@@ -287,7 +287,7 @@ class Executor:
         # Platform default (no env name)
         return ""
 
-    def _resolve_environment(self, task: Task) -> tuple[str, list[str], str]:
+    def _resolve_environment(self, task: Task) -> tuple[str, str]:
         """
         Resolve which environment to use for a task.
 
@@ -301,7 +301,7 @@ class Executor:
         task: Task to resolve environment for
 
         Returns:
-        Tuple of (shell, args, preamble)
+        Tuple of (shell, preamble)
         @athena: 843700029078
         """
         # Check for global override first
@@ -319,12 +319,12 @@ class Executor:
         if env_name:
             env = self.recipe.get_environment(env_name)
             if env:
-                return env.shell, env.args, env.preamble
+                return env.shell, env.preamble
             # If env not found, fall through to platform default
 
         # Use platform default
-        shell, args = self._get_platform_default_environment()
-        return shell, args, ""
+        shell, _ = self._get_platform_default_environment()
+        return shell, ""
 
     def check_task_status(
             self,
@@ -584,7 +584,7 @@ class Executor:
             self._run_task_in_docker(task, env, cmd, working_dir, exported_env_vars)
         else:
             # Regular execution path - use unified script-based execution
-            shell, shell_args, preamble = self._resolve_environment(task)
+            shell, preamble = self._resolve_environment(task)
             self._run_command_as_script(cmd, working_dir, task.name, shell, preamble, exported_env_vars)
 
         # Update state

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -1249,7 +1249,7 @@ class TestEnvironmentResolution(unittest.TestCase):
 
     def test_resolve_environment_with_custom_env(self):
         """
-        Test resolving environment with custom shell and args.
+        Test resolving environment with custom shell and preamble.
         @athena: 82fd09bacad8
         """
         with TemporaryDirectory() as tmpdir:
@@ -1270,9 +1270,8 @@ class TestEnvironmentResolution(unittest.TestCase):
             )
             executor = Executor(recipe, state_manager)
 
-            shell, args, preamble = executor._resolve_environment(tasks["build"])
+            shell, preamble = executor._resolve_environment(tasks["build"])
             self.assertEqual(shell, "zsh")
-            self.assertEqual(args, ["-c"])
             self.assertEqual(preamble, "set -e\n")
 
     @patch("subprocess.run")


### PR DESCRIPTION
## Summary

Implements Phase 2 (steps 5 & 6) of the unified execution feature from issue #63. Removes the deprecated execution methods and simplifies the environment resolution API.

## Changes

1. **Removed deprecated execution methods** (5cf5d90)
   - Deleted `_run_single_line_command()` method
   - Deleted `_run_multiline_command()` method
   - All execution now flows through `_run_command_as_script()`

2. **Simplified environment resolution** (9baed96)
   - Updated `_resolve_environment()` signature: `(shell, args, preamble)` → `(shell, preamble)`
   - Removed shell args from return value (no longer needed for script-based execution)
   - Updated caller in `_run_task()`
   - Updated test to match new signature

## Implementation Approach

Followed the project's philosophy of small, incremental commits:
1. First commit: Remove old execution methods
2. Second commit: Simplify environment resolution API

## Breaking Changes

None for end users. The `Environment.args` field still exists in the dataclass for Docker build arguments. For shell environments, the args field is now ignored (as intended in the design).

## Testing

- Updated `test_resolve_environment_with_custom_env` to match new signature
- All existing integration tests from Phase 1 still apply

## What's Next

Phase 2 is complete. The remaining steps from the original plan:
- Phase 3: Documentation updates
- Phase 4: Comprehensive testing and validation

## Related Issue

Closes #63 (Phase 2 only)

---

Generated with [Claude Code](https://claude.ai/code)