### PR TITLE
Add ProcessRunner abstraction layer

### DIFF
--- a/src/tasktree/process_runner.py
+++ b/src/tasktree/process_runner.py
@@ -8,12 +8,14 @@ import subprocess
 from abc import ABC, abstractmethod
 from typing import Any
 
+__all__ = ['ProcessRunner', 'PassthroughProcessRunner']
+
 
 class ProcessRunner(ABC):
     """Abstract interface for running subprocess commands."""
 
     @abstractmethod
-    def run(self, *args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
+    def run(self, *args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
         """Run a subprocess command.
 
         This method signature matches subprocess.run() to allow for direct
@@ -30,13 +32,13 @@ class ProcessRunner(ABC):
             subprocess.CalledProcessError: If check=True and process exits non-zero
             subprocess.TimeoutExpired: If timeout is exceeded
         """
-        pass
+        ...
 
 
 class PassthroughProcessRunner(ProcessRunner):
     """Process runner that directly delegates to subprocess.run."""
 
-    def run(self, *args: Any, **kwargs: Any) -> subprocess.CompletedProcess:
+    def run(self, *args: Any, **kwargs: Any) -> subprocess.CompletedProcess[Any]:
         """Run a subprocess command via subprocess.run.
 
         Args:

--- a/tests/unit/test_process_runner.py
+++ b/tests/unit/test_process_runner.py
@@ -145,6 +145,17 @@ class TestPassthroughProcessRunner(unittest.TestCase):
 
         mock_run.assert_called_once_with(['sleep', '10'], timeout=1)
 
+    @patch('tasktree.process_runner.subprocess.run')
+    def test_run_calls_subprocess_run_with_shell_true(self, mock_run):
+        """run() passes shell=True parameter to subprocess.run."""
+        mock_result = MagicMock(spec=subprocess.CompletedProcess)
+        mock_run.return_value = mock_result
+
+        result = self.runner.run('echo test', shell=True)
+
+        mock_run.assert_called_once_with('echo test', shell=True)
+        self.assertEqual(result, mock_result)
+
     def test_passthrough_runner_is_process_runner(self):
         """PassthroughProcessRunner implements ProcessRunner interface."""
         self.assertIsInstance(self.runner, ProcessRunner)


### PR DESCRIPTION
## Summary

Creates a new abstraction layer for subprocess execution to improve testability and address issues with subprocess.run and CliRunner interaction.

## Changes

- Add ProcessRunner ABC interface with run abstractmethod
- Implement PassthroughProcessRunner that delegates to subprocess.run
- Add 11 comprehensive unit tests mocking subprocess.run

## Design

- Interface matches subprocess.run signature exactly for drop-in compatibility
- Tests verify correct delegation of all parameter types
- Error propagation maintained (CalledProcessError, TimeoutExpired)

This provides the foundation for cleaner subprocess handling in the task output control feature.

Related to #81

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/kevinchannon/tasktree/actions/runs/21546846888) | [Branch: claude/issue-81-20260131-1543](https://github.com/kevinchannon/tasktree/tree/claude/issue-81-20260131-1543