### PR TITLE
Add --task-output=out option to CLI

### DIFF
--- a/src/tasktree/cli.py
+++ b/src/tasktree/cli.py
@@ -383,8 +383,8 @@ trace: Fine-grained execution tracing""",
         "all",
         "--task-output",
         "-O",
-        click_type=click.Choice(["all"], case_sensitive=False),
-        help="Control task subprocess output display (all: show both stdout and stderr)",
+        click_type=click.Choice(["all", "out"], case_sensitive=False),
+        help="Control task subprocess output display (all: show both stdout and stderr, out: show only stdout)",
     ),
     task_args: Optional[List[str]] = typer.Argument(
         None, help="Task name and arguments"

--- a/tests/e2e/test_task_output.py
+++ b/tests/e2e/test_task_output.py
@@ -1,0 +1,156 @@
+"""E2E tests for task output control via --task-output flag."""
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from . import run_tasktree_cli
+
+
+class TestTaskOutputControl(unittest.TestCase):
+    """
+    Test --task-output flag functionality end-to-end.
+    @athena: TBD
+    """
+
+    def test_task_output_all_shows_both_stdout_and_stderr(self):
+        """
+        Test that --task-output=all shows both stdout and stderr.
+        @athena: TBD
+        """
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+
+            # Create recipe with task that outputs to both stdout and stderr
+            (project_root / "tasktree.yaml").write_text("""
+tasks:
+  mixed-output:
+    outputs: [done.txt]
+    cmd: |
+      echo "This is stdout"
+      echo "This is stderr" >&2
+      echo "done" > done.txt
+""")
+
+            # Execute with --task-output=all
+            result = run_tasktree_cli(
+                ["--task-output=all", "mixed-output"], cwd=project_root
+            )
+
+            # Assert success
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"CLI failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
+            )
+
+            # Verify both stdout and stderr appear in output
+            self.assertIn("This is stdout", result.stdout)
+            self.assertIn("This is stderr", result.stderr)
+
+            # Verify output file was created
+            output_file = project_root / "done.txt"
+            self.assertTrue(output_file.exists(), "Output file not created")
+
+    def test_task_output_out_shows_only_stdout(self):
+        """
+        Test that --task-output=out shows only stdout, suppresses stderr.
+        @athena: TBD
+        """
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+
+            # Create recipe with task that outputs to both stdout and stderr
+            (project_root / "tasktree.yaml").write_text("""
+tasks:
+  mixed-output:
+    outputs: [done.txt]
+    cmd: |
+      echo "This is stdout"
+      echo "This is stderr" >&2
+      echo "done" > done.txt
+""")
+
+            # Execute with --task-output=out
+            result = run_tasktree_cli(
+                ["--task-output=out", "mixed-output"], cwd=project_root
+            )
+
+            # Assert success
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"CLI failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
+            )
+
+            # Verify stdout appears in output
+            self.assertIn("This is stdout", result.stdout)
+
+            # Verify stderr does NOT appear in output
+            # (Note: stderr should be empty since it was suppressed)
+            self.assertNotIn("This is stderr", result.stdout)
+            self.assertNotIn("This is stderr", result.stderr)
+
+            # Verify output file was created
+            output_file = project_root / "done.txt"
+            self.assertTrue(output_file.exists(), "Output file not created")
+
+    def test_task_output_out_case_insensitive(self):
+        """
+        Test that --task-output accepts OUT in various cases (OUT, Out, out).
+        @athena: TBD
+        """
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+
+            # Create recipe with simple task
+            (project_root / "tasktree.yaml").write_text("""
+tasks:
+  simple:
+    outputs: [done.txt]
+    cmd: |
+      echo "stdout message"
+      echo "done" > done.txt
+""")
+
+            # Test uppercase
+            result = run_tasktree_cli(["--task-output=OUT", "simple"], cwd=project_root)
+            self.assertEqual(result.returncode, 0, "Uppercase OUT should be accepted")
+
+            # Test mixed case
+            result = run_tasktree_cli(["--task-output=Out", "simple"], cwd=project_root)
+            self.assertEqual(result.returncode, 0, "Mixed case Out should be accepted")
+
+    def test_task_output_out_with_short_flag(self):
+        """
+        Test that -O out works as short form of --task-output=out.
+        @athena: TBD
+        """
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+
+            # Create recipe with task that outputs to both streams
+            (project_root / "tasktree.yaml").write_text("""
+tasks:
+  mixed-output:
+    outputs: [done.txt]
+    cmd: |
+      echo "This is stdout"
+      echo "This is stderr" >&2
+      echo "done" > done.txt
+""")
+
+            # Execute with -O out
+            result = run_tasktree_cli(["-O", "out", "mixed-output"], cwd=project_root)
+
+            # Assert success
+            self.assertEqual(
+                result.returncode,
+                0,
+                f"CLI failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}",
+            )
+
+            # Verify stdout appears, stderr does not
+            self.assertIn("This is stdout", result.stdout)
+            self.assertNotIn("This is stderr", result.stdout)
+            self.assertNotIn("This is stderr", result.stderr)

--- a/tests/unit/test_process_runner.py
+++ b/tests/unit/test_process_runner.py
@@ -487,6 +487,14 @@ class TestMakeProcessRunner(unittest.TestCase):
         runner = make_process_runner(TaskOutputTypes.NONE)
         self.assertIsInstance(runner, SilentProcessRunner)
 
+    def test_make_process_runner_with_out_returns_stdout_only(self):
+        """
+        make_process_runner(TaskOutputTypes.OUT) returns StdoutOnlyProcessRunner.
+        @athena: TBD
+        """
+        runner = make_process_runner(TaskOutputTypes.OUT)
+        self.assertIsInstance(runner, StdoutOnlyProcessRunner)
+
     def test_make_process_runner_with_invalid_raises_error(self):
         """
         make_process_runner() raises ValueError for invalid TaskOutputTypes.


### PR DESCRIPTION
## Summary

Hooks up the StdoutOnlyProcessRunner to the CLI by adding the "out" option to the --task-output flag.

## Changes

- Update cli.py to allow 'out' choice in --task-output flag
- Add unit test for make_process_runner(TaskOutputTypes.OUT)
- Add 4 e2e tests for task output control using subprocess
- Tests verify stdout-only output and stderr suppression

## Test Results

✅ All 35 process_runner unit tests pass
✅ All 4 new e2e tests pass
✅ No regressions introduced

## Usage

Users can now use the `--task-output=out` flag to show only stdout from tasks:

```bash
# Show only stdout, suppress stderr
tt --task-output=out my-task

# Short form
tt -O out my-task

# Case insensitive
tt -O OUT my-task
```

Related to #81

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/kevinchannon/tasktree/actions/runs/21572143140) | [Branch: claude/issue-81-20260201-2318](https://github.com/kevinchannon/tasktree/tree/claude/issue-81-20260201-2318