### PR TITLE
Add get_session_default_runner() function (Phase 1, Step 1.1)

### DIFF
--- a/src/tasktree/executor.py
+++ b/src/tasktree/executor.py
@@ -282,6 +282,26 @@ class Executor:
         else:
             return "bash", ["-c"]
 
+    @staticmethod
+    def get_session_default_runner() -> Runner:
+        """
+        Get the session default runner based on platform defaults.
+
+        This function returns the hard-coded platform-specific default runner.
+        In future phases, it will be extended to check configuration files
+        at multiple levels (machine, user, project) before falling back to
+        the platform default.
+
+        Returns:
+            Runner: Platform-specific default runner configuration
+        @athena: to-be-generated
+        """
+        is_windows = platform.system() == "Windows"
+        if is_windows:
+            return Runner(name="__platform_default__", shell="cmd", args=["/c"])
+        else:
+            return Runner(name="__platform_default__", shell="bash", args=["-c"])
+
     def _get_effective_runner_name(self, task: Task) -> str:
         """
         Get the effective runner name for a task.

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -1946,5 +1946,54 @@ class TestExecutorProcessRunner(unittest.TestCase):
             del os.environ["CUSTOM_SHELL"]
 
 
+class TestGetSessionDefaultRunner(unittest.TestCase):
+    """
+    Tests for get_session_default_runner() function.
+    @athena: to-be-generated
+    """
+
+    @patch("platform.system")
+    def test_returns_bash_on_unix(self, mock_system):
+        """
+        Test that get_session_default_runner returns bash runner on Unix platforms.
+        @athena: to-be-generated
+        """
+        mock_system.return_value = "Linux"
+        runner = Executor.get_session_default_runner()
+
+        self.assertEqual(runner.name, "__platform_default__")
+        self.assertEqual(runner.shell, "bash")
+        self.assertEqual(runner.args, ["-c"])
+        self.assertEqual(runner.preamble, "")
+
+    @patch("platform.system")
+    def test_returns_bash_on_macos(self, mock_system):
+        """
+        Test that get_session_default_runner returns bash runner on macOS.
+        @athena: to-be-generated
+        """
+        mock_system.return_value = "Darwin"
+        runner = Executor.get_session_default_runner()
+
+        self.assertEqual(runner.name, "__platform_default__")
+        self.assertEqual(runner.shell, "bash")
+        self.assertEqual(runner.args, ["-c"])
+        self.assertEqual(runner.preamble, "")
+
+    @patch("platform.system")
+    def test_returns_cmd_on_windows(self, mock_system):
+        """
+        Test that get_session_default_runner returns cmd runner on Windows.
+        @athena: to-be-generated
+        """
+        mock_system.return_value = "Windows"
+        runner = Executor.get_session_default_runner()
+
+        self.assertEqual(runner.name, "__platform_default__")
+        self.assertEqual(runner.shell, "cmd")
+        self.assertEqual(runner.args, ["/c"])
+        self.assertEqual(runner.preamble, "")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implements Phase 1, Step 1.1 of the configuration file support feature.

## Changes

- Added `Executor.get_session_default_runner()` static method that returns a Runner object with platform-specific defaults
- Added unit tests covering Linux, macOS, and Windows platforms
- Function will be extended in future phases to check configuration files

Related to #68

----

Generated with [Claude Code](https://claude.ai/code)