### PR TITLE
Update _resolve_runner() to use get_session_default_runner() (Phase 1, Step 1.2)

### DIFF
--- a/src/tasktree/executor.py
+++ b/src/tasktree/executor.py
@@ -268,21 +268,6 @@ class Executor:
         return env
 
     @staticmethod
-    def _get_platform_default_environment() -> tuple[str, list[str]]:
-        """
-        Get default shell and args for current platform.
-
-        Returns:
-        Tuple of (shell, args) for platform default
-        @athena: 8b7fa81073af
-        """
-        is_windows = platform.system() == "Windows"
-        if is_windows:
-            return "cmd", ["/c"]
-        else:
-            return "bash", ["-c"]
-
-    @staticmethod
     def get_session_default_runner() -> Runner:
         """
         Get the session default runner based on platform defaults.


### PR DESCRIPTION
Implements Phase 1, Step 1.2 of the configuration file support feature.

## Changes

- Updated `_resolve_runner()` to call `get_session_default_runner()` instead of `_get_platform_default_environment()`
- Extracts shell and preamble from returned Runner object
- Maintains identical behavior (preamble defaults to empty string)
- Centralizes all runner resolution through `get_session_default_runner()`

This prepares the codebase for Phase 2, where `get_session_default_runner()` will be extended to check configuration files.

Related to #68

----

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/kevinchannon/tasktree/actions/runs/21672295940) | [Branch: claude/issue-68-20260204-1256](https://github.com/kevinchannon/tasktree/tree/claude/issue-68-20260204-1256