### PR TITLE
Phase 6 Complete: Enhanced Error Messages

### DIFF
--- a/src/tasktree/config.py
+++ b/src/tasktree/config.py
@@ -120,6 +120,23 @@ def find_project_config(start_dir: Path) -> Optional[Path]:
 class ConfigError(Exception):
     """
     Raised when a configuration file is invalid.
+
+    All ConfigError messages include the full path to the config file that caused
+    the error, making it easy to identify and fix configuration issues.
+
+    Error Message Format:
+        "Error in config file '{path}': {specific_error_message}"
+
+    Examples:
+        - "Error in config file '/home/user/.config/tasktree/config.yml': 'runners' must be a dictionary"
+        - "Error in config file '.tasktree-config.yml': Field 'shell' must be a string"
+        - "Error parsing YAML in config file '/etc/tasktree/config.yml': mapping values are not allowed here"
+
+    This consistent format allows users to:
+    - Quickly identify which config file has the issue
+    - Understand what went wrong
+    - Fix the problem efficiently
+
     @athena: to-be-generated
     """
 


### PR DESCRIPTION
## Changes

Completes Phase 6 of the configuration file support feature (#68). Adds comprehensive field type validation and ensures all error messages include config file context.

### Phase 6 Summary

- **Step 6.1**: Added comprehensive field type validation
- **Step 6.2**: Enhanced error documentation and added verification test

### Implementation Details

**Step 6.1: Add comprehensive field type validation** (Commit d0f3293)

- Added type validation for all runner config fields:
  - String fields: `shell`, `preamble`, `working_dir`, `dockerfile`, `context`
  - List fields: `args`, `volumes`, `ports`, `extra_args`
  - Dict fields: `env_vars`
  - Boolean fields: `run_as_root`
- All validation errors include the full config file path
- Added 11 comprehensive tests in `TestConfigFieldValidation` class

**Step 6.2: Document error message requirements** (Commit 9b1cfc7)

- Enhanced `ConfigError` class documentation:
  - Documented consistent error message format
  - Explained how all errors include config file path
  - Provided real-world examples of error messages
- Added meta-test (`TestErrorMessageContext`):
  - Verifies all ConfigError messages include config file path
  - Tests 10 different error scenarios
  - Uses subTest for clear test reporting

### Error Message Format

All error messages follow a consistent format:
```
Error in config file '{path}': {specific_error_message}
```

Examples:
- `Error in config file '/home/user/.config/tasktree/config.yml': Field 'shell' must be a string`
- `Error in config file '.tasktree-config.yml': Field 'volumes' must be a list`
- `Error in config file '/etc/tasktree/config.yml': 'runners' must be a dictionary`
- `Error parsing YAML in config file 'config.yml': mapping values are not allowed here`

### Files Changed

- `src/tasktree/config.py`: Added field type validation and enhanced ConfigError documentation
- `tests/unit/test_config.py`: Added 12 new tests (11 for field validation + 1 meta-test)

### Phase 6 Complete

All error messages now:
- Include the full config file path
- Clearly state what went wrong
- Indicate which field or constraint failed
- Provide actionable information for users to fix the issue

### Next Steps

Phases 1-6 are now complete. Remaining phase from the original plan:
- Phase 7: Integration testing & documentation (optional)

Related to #68

----

Generated with [Claude Code](https://claude.ai/code)