### PR TITLE
Fix Docker runner field names in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,14 +146,13 @@ runners:
     # OR
     dockerfile: path/to/Dockerfile  # Docker runner
     context: build-context-dir
-    image: optional-image-name
     volumes:
       - host_path:container_path[:ro]
     ports:
       - "host:container"
-    build_args:
+    args:
       ARG_NAME: value
-    environment:
+    env_vars:
       ENV_VAR: value
 
 variables:


### PR DESCRIPTION
Fixes #125

Corrected three documentation errors in CLAUDE.md:
- Removed non-existent 'image:' field
- Changed 'build_args:' to 'args:' (correct field name)
- Changed 'environment:' to 'env_vars:' (correct field name)

These corrections align the documentation with the actual implementation as verified by the JSON schema and source code.

Generated with [Claude Code](https://claude.ai/code)