### PR TITLE
Remove redundant shebang handling

### DIFF
--- a/src/tasktree/docker.py
+++ b/src/tasktree/docker.py
@@ -179,14 +179,14 @@ class DockerManager:
 
         # Create temp script on host with the interpreter's preamble + command,
         # then mount into container. The extension is the interpreter's literal ext,
-        # not the host platform. No shebang: the interpreter is invoked explicitly.
+        # not the host platform. The interpreter is invoked explicitly, so no shebang
+        # is needed.
         try:
             with TempScript(
                 logger=self._logger,
                 cmd=cmd,
                 preamble=interpreter.preamble,
                 interpreter=interpreter,
-                use_shebang=False,
             ) as script_path:
                 # Build docker run command from the shared flags (user mapping,
                 # run args, volume mounts incl. the auto repo-mount, ports, env).

--- a/src/tasktree/executor.py
+++ b/src/tasktree/executor.py
@@ -41,6 +41,23 @@ def _supports_fileno(stream) -> bool:
         return False
 
 
+def _extract_shebang_interpreter(shebang_line: str) -> str:
+    """Extract the interpreter name from a shebang line.
+
+    Examples:
+        '#!/usr/bin/env bash' -> 'bash'
+        '#!/bin/bash'         -> 'bash'
+        '#!/usr/bin/python3'  -> 'python3'
+    """
+    path_part = shebang_line[2:].strip()
+    parts = path_part.split()
+    if not parts:
+        return ""
+    if os.path.basename(parts[0]) == "env" and len(parts) > 1:
+        return parts[1]
+    return os.path.basename(parts[0])
+
+
 @dataclass
 class TaskStatus:
     """
@@ -1032,9 +1049,12 @@ class Executor:
             task.cmd, builtin_vars, regular_args, exported_args, task.name
         )
 
-        # A leading shebang has no effect: the interpreter is chosen explicitly,
-        # not by executing the script directly. Point the user at 'interpreter:'.
-        self._warn_if_cmd_has_shebang(cmd)
+        # Resolve interpreter early so the shebang check can compare against it.
+        interpreter = self._resolve_interpreter(task)
+
+        # Warn if the user wrote a shebang in cmd: it has no effect because the
+        # interpreter is always invoked explicitly, not by running the script directly.
+        self._warn_if_cmd_has_shebang(cmd, interpreter)
 
         # Check if task uses Docker environment
         env_name = self._get_effective_runner_name(task)
@@ -1061,8 +1081,6 @@ class Executor:
             # Shell execution path - either local or inside an existing container.
             # The interpreter (and its preamble) is resolved the same way in both
             # cases; a nested-in-container task uses its runner's interpreter.
-            interpreter = self._resolve_interpreter(task)
-
             self._run_command_as_script(
                 cmd,
                 working_dir,
@@ -1082,16 +1100,33 @@ class Executor:
         # Update state
         self._update_state(task, args_dict, process_runner)
 
-    def _warn_if_cmd_has_shebang(self, cmd: str) -> None:
-        """Warn that a leading shebang in a task command is ignored.
+    def _warn_if_cmd_has_shebang(self, cmd: str, interpreter: Interpreter) -> None:
+        """Warn if a shebang in the task cmd field will be ineffective.
 
-        Commands run via an explicitly chosen interpreter, so a ``#!`` line is
-        treated as an ordinary first line rather than selecting an interpreter.
+        On Windows shebangs are ignored entirely. On other platforms the
+        shebang has no effect because the interpreter is invoked explicitly;
+        warn only when the shebang specifies a different interpreter than the
+        one that will actually run the script (a silent mismatch is confusing).
         """
-        if cmd.lstrip().startswith("#!"):
+        stripped = cmd.lstrip()
+        if not stripped.startswith("#!"):
+            return
+
+        shebang_line = stripped.split("\n")[0]
+
+        if platform.system() == "Windows":
             self.logger.warn(
-                "[yellow]Shebang on line 1 of cmd is ignored. "
-                "Set 'interpreter:' to choose a non-default interpreter.[/yellow]"
+                "[yellow]Shebang detected in cmd. "
+                "On Windows, shebangs are ignored entirely.[/yellow]"
+            )
+            return
+
+        shebang_interpreter = _extract_shebang_interpreter(shebang_line)
+        if shebang_interpreter and shebang_interpreter != interpreter.cmd:
+            self.logger.warn(
+                f"[yellow]Shebang in cmd specifies '{shebang_interpreter}' but the task will "
+                f"run with '{interpreter.cmd}'. The shebang has no effect — set 'interpreter:' "
+                f"to choose a non-default interpreter.[/yellow]"
             )
 
     def _run_command_as_script(
@@ -1130,15 +1165,14 @@ class Executor:
         # Prepare environment with exported args and call chain
         env = self._prepare_env_with_exports(exported_env_vars, call_chain)
 
-        # Create temporary script using context manager — no shebang needed since
-        # the interpreter is passed explicitly in the subprocess call. The script
+        # Create temporary script using context manager. The interpreter is passed
+        # explicitly in the subprocess call, so no shebang is needed. The script
         # extension is the interpreter's literal ext (empty = no extension).
         with TempScript(
             logger=self.logger,
             cmd=cmd,
             preamble=interpreter.preamble,
             interpreter=interpreter,
-            use_shebang=False,
         ) as script_path:
             run_cmd = interpreter.invocation + [str(script_path)]
 

--- a/src/tasktree/executor.py
+++ b/src/tasktree/executor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import os
 import platform
+import shlex
 import subprocess
 import sys
 import time
@@ -41,20 +42,30 @@ def _supports_fileno(stream) -> bool:
         return False
 
 
-def _extract_shebang_interpreter(shebang_line: str) -> str:
+def _extract_shebang_interpreter(shebang_line: str) -> str | None:
     """Extract the interpreter name from a shebang line.
 
+    Returns None when no interpreter can be deduced from the line.
+
     Examples:
-        '#!/usr/bin/env bash' -> 'bash'
-        '#!/bin/bash'         -> 'bash'
-        '#!/usr/bin/python3'  -> 'python3'
+        '#!/usr/bin/env bash'       -> 'bash'
+        '#!/usr/bin/env -S python3' -> 'python3'
+        '#!/usr/bin/env'            -> None
+        '#!/bin/bash'               -> 'bash'
+        '#!/usr/bin/python3'        -> 'python3'
     """
     path_part = shebang_line[2:].strip()
     parts = path_part.split()
     if not parts:
-        return ""
-    if os.path.basename(parts[0]) == "env" and len(parts) > 1:
-        return parts[1]
+        return None
+    if os.path.basename(parts[0]) == "env":
+        # Skip any env flags (e.g. '-S') to find the real interpreter; an env
+        # with no following interpreter (just flags, or nothing) has nothing
+        # to compare against.
+        for token in parts[1:]:
+            if not token.startswith("-"):
+                return token
+        return None
     return os.path.basename(parts[0])
 
 
@@ -1073,6 +1084,7 @@ class Executor:
                 env,
                 cmd,
                 working_dir,
+                interpreter,
                 process_runner,
                 exported_env_vars,
                 updated_chain,
@@ -1122,7 +1134,12 @@ class Executor:
             return
 
         shebang_interpreter = _extract_shebang_interpreter(shebang_line)
-        if shebang_interpreter and shebang_interpreter != interpreter.cmd:
+        # interpreter.cmd is stored verbatim from YAML and may be a full path
+        # and/or carry arguments (e.g. '/bin/bash', 'python3 -u'). Compare bare
+        # interpreter names so an agreeing shebang doesn't trip a false warning.
+        cmd_tokens = shlex.split(interpreter.cmd)
+        interpreter_name = os.path.basename(cmd_tokens[0]) if cmd_tokens else ""
+        if shebang_interpreter is not None and shebang_interpreter != interpreter_name:
             self.logger.warn(
                 f"[yellow]Shebang in cmd specifies '{shebang_interpreter}' but the task will "
                 f"run with '{interpreter.cmd}'. The shebang has no effect — set 'interpreter:' "
@@ -1325,6 +1342,7 @@ class Executor:
         env: Any,
         cmd: str,
         working_dir: Path,
+        interpreter: Interpreter,
         process_runner: ProcessRunner,
         exported_env_vars: dict[str, str] | None = None,
         call_chain: str | None = None,
@@ -1337,6 +1355,7 @@ class Executor:
         env: Docker environment configuration
         cmd: Command to execute
         working_dir: Host working directory
+        interpreter: Resolved interpreter for the task
         process_runner: ProcessRunner instance to use for subprocess execution
         exported_env_vars: Exported arguments to set as environment variables
         call_chain: TT_CALL_CHAIN value for recursion detection
@@ -1403,7 +1422,7 @@ class Executor:
                 working_dir=working_dir,
                 container_working_dir=container_working_dir,
                 process_runner=process_runner,
-                interpreter=self._resolve_interpreter(task),
+                interpreter=interpreter,
             )
         except docker_module.DockerError as e:
             raise ExecutionError(str(e)) from e

--- a/src/tasktree/temp_script.py
+++ b/src/tasktree/temp_script.py
@@ -9,7 +9,6 @@ between containerized and non-containerized execution paths.
 
 import os
 import platform
-import stat
 import tempfile
 import types
 from pathlib import Path
@@ -31,13 +30,14 @@ class TempScript:
 
     The context manager creates a temporary script file with the appropriate
     platform-specific extension (.sh for Unix/macOS, .bat for Windows),
-    writes a shebang (Unix/macOS only), optional preamble, and the command
-    to execute. On Unix/macOS, the script is made executable.
+    writes an optional preamble, and the command to execute. The interpreter
+    is always passed explicitly when invoking the script, so no shebang is
+    written and no executable bit is set.
 
     Usage:
         with TempScript(logger=my_logger, cmd="echo hello", preamble="set -e", interpreter=Interpreter(cmd="bash")) as script_path:
             # script_path is a Path object pointing to the temp script
-            subprocess.run([str(script_path)], check=True)
+            subprocess.run(["bash", str(script_path)], check=True)
         # Script is automatically cleaned up after the with block
 
     """
@@ -48,7 +48,6 @@ class TempScript:
         cmd: str,
         preamble: str = "",
         script_extension: str | None = None,
-        use_shebang: bool | None = None,
         interpreter: Interpreter | None = None,
     ):
         """
@@ -60,11 +59,8 @@ class TempScript:
             preamble: Optional preamble to prepend to command
             script_extension: Optional override for script file extension (e.g., ".sh", ".bat", ".ps1").
                             If None, derived from ``interpreter`` when provided, otherwise the platform.
-            use_shebang: Optional override for whether to add shebang.
-                        If None, determined from platform (True on Unix/macOS, False on Windows).
             interpreter: Optional Interpreter describing how the script is run.
-                        When provided, supplies the shebang command and the
-                        default script extension.
+                        When provided, supplies the default script extension.
 
         """
         self.cmd = cmd
@@ -72,7 +68,6 @@ class TempScript:
         self.logger = logger
         self.script_path: Path | None = None
         self.script_extension = script_extension
-        self.use_shebang = use_shebang
         self.interpreter = interpreter
 
     def __enter__(self) -> Path:
@@ -80,14 +75,7 @@ class TempScript:
         Create temp script and return path.
 
         Creates a temporary script file with platform-appropriate extension,
-        writes shebang (Unix/macOS only by default), preamble, and command.
-        Makes the script executable on Unix/macOS.
-
-        Note: There is a small race condition window between file creation
-        (with delete=False) and chmod on Unix/macOS. A malicious process could
-        potentially access the file before permissions are set. This is accepted
-        as the temp directory should have appropriate permissions and the window
-        is very small.
+        writes optional preamble and command.
 
         Returns:
             Path object pointing to the temporary script file
@@ -102,12 +90,6 @@ class TempScript:
         else:
             script_ext = ".bat" if _IS_WINDOWS else ".sh"
 
-        # Determine whether to use shebang (use override if provided, otherwise platform default)
-        if self.use_shebang is not None:
-            should_use_shebang = self.use_shebang
-        else:
-            should_use_shebang = not _IS_WINDOWS
-
         self.logger.debug(f"Creating temp script with extension {script_ext}")
 
         # Create temporary script file with explicit UTF-8 encoding
@@ -118,19 +100,6 @@ class TempScript:
             encoding="utf-8",
         ) as script_file:
             script_path_str = script_file.name
-
-            # Add shebang if enabled and not already present in command
-            if should_use_shebang:
-                if not self.cmd.startswith("#!"):
-                    # Derive the shebang interpreter from the configured interpreter.
-                    shebang_cmd = (
-                        self.interpreter.invocation[0]
-                        if self.interpreter is not None
-                        else "sh"
-                    )
-                    shebang = f"#!/usr/bin/env {shebang_cmd}\n"
-                    script_file.write(shebang)
-                    self.logger.debug(f"Added shebang: {shebang.strip()}")
 
             # Add preamble if provided
             if self.preamble:
@@ -147,14 +116,6 @@ class TempScript:
         self.script_path = Path(script_path_str)
 
         self.logger.debug(f"Created temp script at: {self.script_path}")
-
-        # Make executable on Unix/macOS (only for non-Windows scripts)
-        if not _IS_WINDOWS and script_ext == ".sh":
-            os.chmod(
-                self.script_path,
-                os.stat(self.script_path).st_mode | stat.S_IEXEC
-            )
-            self.logger.debug("Set executable permissions on script")
 
         return self.script_path
 

--- a/tasktree.yaml
+++ b/tasktree.yaml
@@ -2,7 +2,7 @@
 runners:
   default: bash-strict
   bash-strict:
-    shell:
+    interpreter:
       cmd: bash
       preamble: set -euo pipefail
   tt-test:

--- a/tests/unit/test_docker.py
+++ b/tests/unit/test_docker.py
@@ -903,7 +903,7 @@ class TestDockerManager(unittest.TestCase):
     @patch("tasktree.docker.os.getgid", create=True, return_value=1000)
     def test_run_in_container_with_windows_shell(self, mock_getgid, mock_getuid, mock_platform, mock_run):
         """
-        Test that Windows shells (cmd.exe) use appropriate script extension and no shebang.
+        Test that Windows shells (cmd.exe) use appropriate script extension (.bat).
         """
         mock_platform.return_value = "Linux"  # Host platform (doesn't matter for container)
 

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -519,8 +519,31 @@ class TestResolveInterpreter(unittest.TestCase):
         self.assertEqual(ex._resolve_interpreter(task), container_default_interpreter())
 
 
+class TestExtractShebangInterpreter(unittest.TestCase):
+    """Tests for the _extract_shebang_interpreter helper."""
+
+    def _extract(self, line: str) -> str:
+        from tasktree.executor import _extract_shebang_interpreter
+        return _extract_shebang_interpreter(line)
+
+    def test_env_form(self):
+        self.assertEqual(self._extract("#!/usr/bin/env bash"), "bash")
+
+    def test_env_form_python(self):
+        self.assertEqual(self._extract("#!/usr/bin/env python3"), "python3")
+
+    def test_direct_path_form(self):
+        self.assertEqual(self._extract("#!/bin/bash"), "bash")
+
+    def test_direct_path_usr(self):
+        self.assertEqual(self._extract("#!/usr/bin/python3"), "python3")
+
+    def test_empty_shebang(self):
+        self.assertEqual(self._extract("#!"), "")
+
+
 class TestShebangWarning(unittest.TestCase):
-    """Tests for the shebang-in-cmd warning (issue #201, step 9)."""
+    """Tests for the shebang-in-cmd warning."""
 
     def _make_executor_with_logger(self):
         tmp = TemporaryDirectory()
@@ -535,21 +558,44 @@ class TestShebangWarning(unittest.TestCase):
         ex = Executor(recipe, StateManager(project_root), logger, make_process_runner)
         return ex, logger
 
-    def test_shebang_cmd_warns_via_logger(self):
+    @unittest.skipIf(platform.system() == "Windows", "Unix-only: mismatch warning test")
+    def test_shebang_mismatch_warns(self):
+        """Shebang specifying a different interpreter than the task runner triggers a warning."""
         ex, logger = self._make_executor_with_logger()
-        ex._warn_if_cmd_has_shebang("#!/usr/bin/env python3\nprint('hi')")
+        ex._warn_if_cmd_has_shebang(
+            "#!/usr/bin/env python3\nprint('hi')", Interpreter(cmd="sh")
+        )
         logger.warn.assert_called_once()
         self.assertIn("Shebang", logger.warn.call_args[0][0])
 
-    def test_leading_whitespace_shebang_warns(self):
+    @unittest.skipIf(platform.system() == "Windows", "Unix-only: match no-warning test")
+    def test_shebang_matches_interpreter_does_not_warn(self):
+        """Shebang that matches the actual interpreter should not produce a warning."""
         ex, logger = self._make_executor_with_logger()
-        ex._warn_if_cmd_has_shebang("\n  #!/bin/bash\necho hi")
+        ex._warn_if_cmd_has_shebang(
+            "#!/usr/bin/env bash\necho hi", Interpreter(cmd="bash")
+        )
+        logger.warn.assert_not_called()
+
+    @unittest.skipIf(platform.system() == "Windows", "Unix-only: leading whitespace test")
+    def test_leading_whitespace_shebang_mismatch_warns(self):
+        """Leading whitespace before the shebang still triggers a mismatch warning."""
+        ex, logger = self._make_executor_with_logger()
+        ex._warn_if_cmd_has_shebang("\n  #!/bin/bash\necho hi", Interpreter(cmd="sh"))
         logger.warn.assert_called_once()
 
     def test_cmd_without_shebang_does_not_warn(self):
         ex, logger = self._make_executor_with_logger()
-        ex._warn_if_cmd_has_shebang("echo '#! not a shebang'")
+        ex._warn_if_cmd_has_shebang("echo '#! not a shebang'", Interpreter(cmd="sh"))
         logger.warn.assert_not_called()
+
+    @unittest.skipUnless(platform.system() == "Windows", "Windows-only warning test")
+    def test_windows_shebang_warns_ignored(self):
+        """On Windows, any shebang triggers a warning that shebangs are fully ignored."""
+        ex, logger = self._make_executor_with_logger()
+        ex._warn_if_cmd_has_shebang("#!/bin/bash\necho hi", Interpreter(cmd="cmd.exe"))
+        logger.warn.assert_called_once()
+        self.assertIn("Windows", logger.warn.call_args[0][0])
 
 
 class TestMissingOutputs(unittest.TestCase):

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -539,7 +539,15 @@ class TestExtractShebangInterpreter(unittest.TestCase):
         self.assertEqual(self._extract("#!/usr/bin/python3"), "python3")
 
     def test_empty_shebang(self):
-        self.assertEqual(self._extract("#!"), "")
+        self.assertIsNone(self._extract("#!"))
+
+    def test_env_with_split_string_flag(self):
+        """env -S passes a multi-arg shebang; the interpreter follows the flag."""
+        self.assertEqual(self._extract("#!/usr/bin/env -S python3"), "python3")
+
+    def test_env_without_interpreter(self):
+        """A bare env shebang has no deducible interpreter."""
+        self.assertIsNone(self._extract("#!/usr/bin/env"))
 
 
 class TestShebangWarning(unittest.TestCase):
@@ -583,6 +591,24 @@ class TestShebangWarning(unittest.TestCase):
         ex, logger = self._make_executor_with_logger()
         ex._warn_if_cmd_has_shebang("\n  #!/bin/bash\necho hi", Interpreter(cmd="sh"))
         logger.warn.assert_called_once()
+
+    @unittest.skipIf(platform.system() == "Windows", "Unix-only: full-path match test")
+    def test_full_path_interpreter_matching_shebang_does_not_warn(self):
+        """A full-path interpreter cmd that agrees with the shebang must not warn."""
+        ex, logger = self._make_executor_with_logger()
+        ex._warn_if_cmd_has_shebang(
+            "#!/bin/bash\necho hi", Interpreter(cmd="/bin/bash")
+        )
+        logger.warn.assert_not_called()
+
+    @unittest.skipIf(platform.system() == "Windows", "Unix-only: multi-token match test")
+    def test_interpreter_with_args_matching_shebang_does_not_warn(self):
+        """An interpreter cmd carrying arguments still matches on the bare name."""
+        ex, logger = self._make_executor_with_logger()
+        ex._warn_if_cmd_has_shebang(
+            "#!/usr/bin/env python3\nprint('hi')", Interpreter(cmd="python3 -u")
+        )
+        logger.warn.assert_not_called()
 
     def test_cmd_without_shebang_does_not_warn(self):
         ex, logger = self._make_executor_with_logger()

--- a/tests/unit/test_temp_script.py
+++ b/tests/unit/test_temp_script.py
@@ -8,10 +8,9 @@ temporary shell script files.
 
 import os
 import platform
-import stat
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from helpers.logging import logger_stub
 from tasktree.temp_script import TempScript
@@ -41,13 +40,10 @@ class TestTempScript(unittest.TestCase):
             expected_ext = ".bat" if is_windows else ".sh"
             self.assertTrue(str(script_path).endswith(expected_ext))
 
-            # Verify content
+            # Verify content contains command (no shebang prepended)
             content = script_path.read_text()
             self.assertIn(cmd, content)
-
-            # On Unix/macOS, verify shebang is present
-            if not is_windows:
-                self.assertTrue(content.startswith("#!/usr/bin/env sh\n"))
+            self.assertFalse(content.startswith("#!"))
 
         # Verify cleanup - script should be deleted after context exit
         self.assertFalse(script_path.exists())
@@ -109,45 +105,6 @@ class TestTempScript(unittest.TestCase):
 
         self.assertFalse(script_path.exists())
 
-    def test_custom_shell(self):
-        """
-        Test TempScript uses custom shell in shebang.
-
-        """
-        is_windows = platform.system() == "Windows"
-        if is_windows:
-            self.skipTest("Shebang test only applicable on Unix/macOS")
-
-        cmd = "echo hello"
-        shell = "zsh"
-
-        with TempScript(logger=logger_stub, cmd=cmd, interpreter=Interpreter(cmd=shell)) as script_path:
-            content = script_path.read_text()
-
-            # Verify custom shell in shebang
-            self.assertTrue(content.startswith("#!/usr/bin/env zsh\n"))
-
-        self.assertFalse(script_path.exists())
-
-    def test_script_is_executable_on_unix(self):
-        """
-        Test TempScript makes script executable on Unix/macOS.
-
-        """
-        is_windows = platform.system() == "Windows"
-        if is_windows:
-            self.skipTest("Executable test only applicable on Unix/macOS")
-
-        cmd = "echo hello"
-
-        with TempScript(logger=logger_stub, cmd=cmd) as script_path:
-            # Verify script is executable
-            file_stat = os.stat(script_path)
-            is_executable = bool(file_stat.st_mode & stat.S_IEXEC)
-            self.assertTrue(is_executable)
-
-        self.assertFalse(script_path.exists())
-
     def test_cleanup_on_exception(self):
         """
         Test TempScript cleans up script even when exception occurs.
@@ -184,28 +141,6 @@ class TestTempScript(unittest.TestCase):
 
         # Test passes if no exception was raised
 
-    def test_command_with_existing_shebang(self):
-        """
-        Test TempScript does not add shebang if command already has one.
-
-        """
-        is_windows = platform.system() == "Windows"
-        if is_windows:
-            self.skipTest("Shebang test only applicable on Unix/macOS")
-
-        cmd = "#!/bin/sh\necho hello"
-
-        with TempScript(logger=logger_stub, cmd=cmd, interpreter=Interpreter(cmd="bash")) as script_path:
-            content = script_path.read_text()
-
-            # Verify original shebang is preserved
-            self.assertTrue(content.startswith("#!/bin/sh\n"))
-
-            # Verify bash shebang was NOT added
-            self.assertNotIn("#!/usr/bin/env bash", content)
-
-        self.assertFalse(script_path.exists())
-
     def test_empty_command(self):
         """
         Test TempScript handles empty command string.
@@ -216,10 +151,8 @@ class TestTempScript(unittest.TestCase):
         with TempScript(logger=logger_stub, cmd=cmd) as script_path:
             content = script_path.read_text()
 
-            # On Unix/macOS, should have shebang even with empty command
-            is_windows = platform.system() == "Windows"
-            if not is_windows:
-                self.assertTrue(content.startswith("#!/usr/bin/env sh\n"))
+            # No shebang should be written
+            self.assertFalse(content.startswith("#!"))
 
             self.assertTrue(script_path.exists())
 
@@ -238,24 +171,17 @@ class TestTempScript(unittest.TestCase):
 
         self.assertFalse(script_path.exists())
 
+    @unittest.skipUnless(platform.system() == "Windows", "Windows-specific test")
     def test_windows_bat_extension(self):
         """
         Test TempScript uses .bat extension on Windows.
 
         """
-        is_windows = platform.system() == "Windows"
-        if not is_windows:
-            self.skipTest("Windows-specific test")
-
         cmd = "echo hello"
 
         with TempScript(logger=logger_stub, cmd=cmd) as script_path:
             # Verify .bat extension
             self.assertTrue(str(script_path).endswith(".bat"))
-
-            # Verify no shebang on Windows
-            content = script_path.read_text()
-            self.assertNotIn("#!/usr/bin/env", content)
 
         self.assertFalse(script_path.exists())
 
@@ -306,19 +232,19 @@ class TestTempScriptInterpreter(unittest.TestCase):
         ) as script_path:
             self.assertTrue(str(script_path).endswith(".custom"))
 
-    @unittest.skipIf(platform.system() == "Windows", "Shebang is Unix-only")
-    def test_interpreter_supplies_shebang_command(self):
-        """The interpreter's executable is used in the shebang line."""
-        from tasktree.interpreter import Interpreter
-
+    def test_no_shebang_written_for_any_interpreter(self):
+        """TempScript never writes a shebang — the interpreter is always invoked explicitly."""
         cmd = "echo hello"
-        with TempScript(
-            logger=logger_stub,
-            cmd=cmd,
-            interpreter=Interpreter(cmd="zsh"),
-            use_shebang=True,
-        ) as script_path:
-            self.assertTrue(script_path.read_text().startswith("#!/usr/bin/env zsh\n"))
+        for shell in ("bash", "zsh", "sh", "python3"):
+            with TempScript(
+                logger=logger_stub,
+                cmd=cmd,
+                interpreter=Interpreter(cmd=shell),
+            ) as script_path:
+                self.assertFalse(
+                    script_path.read_text().startswith("#!"),
+                    f"No shebang expected for interpreter '{shell}'",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #204

## Summary

- Removed shebang writing, `use_shebang` parameter, and chmod from `TempScript` — the interpreter is always invoked explicitly
- Removed `use_shebang=False` from executor and docker call sites
- Updated `_warn_if_cmd_has_shebang` to compare shebang vs actual interpreter; warns on Windows that shebangs are ignored entirely
- Added `_extract_shebang_interpreter` helper for both `#!/usr/bin/env X` and `#!/path/to/X` forms
- Removed all redundant shebang/chmod tests; added interpreter-aware warning tests

Generated with [Claude Code](https://claude.ai/code)