### PR TITLE
Add tt.uid/tt.gid builtin variables and document containerised runners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.venv-docker
 env/
 venv/
 ENV/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,8 @@ Tasks have access to these built-in template variables:
 - `{{ tt.timestamp_unix }}`: Unix timestamp
 - `{{ tt.user_home }}`: User's home directory
 - `{{ tt.user_name }}`: Current username
+- `{{ tt.uid }}`: Host numeric user ID (POSIX only)
+- `{{ tt.gid }}`: Host numeric group ID (POSIX only)
 
 ## Key Features
 
@@ -390,7 +392,7 @@ When adding a new completion prefix (e.g., `env.*`, `dep.*`, `self.*`):
 **Implemented:**
 - ✅ Server lifecycle (initialize, shutdown, exit)
 - ✅ Document management (textDocument/didOpen, textDocument/didChange)
-- ✅ `tt.*` completion - Built-in variables (8 variables from executor.py)
+- ✅ `tt.*` completion - Built-in variables (10 variables from executor.py)
 - ✅ `var.*` completion - User-defined variables (from variables section)
 - ✅ `arg.*` completion - Task arguments (context-aware, scoped to current task)
 - ✅ `env.*` completion - Environment variables (from current process env, sorted alphabetically, no scoping)

--- a/README.md
+++ b/README.md
@@ -176,10 +176,10 @@ A task runs if:
 
 ### Docker Integration
 
-> **⚠️ Not ready for release**: Docker runner support is under active development and is not yet ready for end users. Do not document or expose this feature in user-facing documentation.
+See [Containerised Runners (Docker)](src/tasktree/README.md#containerised-runners-docker) in the user guide for full usage documentation.
 
 - Builds images from Dockerfiles
-- Mounts state file at `/tasktree-internal/.tasktree-state`
+- Auto-mounts the project root (including the state file) at its own resolved host path
 - User mapping (run as host UID:GID by default)
 - Volume mounts and port mappings
 - Build arguments and environment variables

--- a/src/tasktree/README.md
+++ b/src/tasktree/README.md
@@ -2143,7 +2143,7 @@ tasks:
 - **Working directory**: `{{ tt.working_dir }}` reflects the task's `working_dir` setting, or the project root if not specified
 - **Recipe vs Project**: `{{ tt.recipe_dir }}` points to where the recipe file is located, while `{{ tt.project_root }}` points to where the `.tasktree-state` file is (usually the same, but can differ)
 - **Username fallback**: If `os.getlogin()` fails, `{{ tt.user_name }}` falls back to `$USER` or `$USERNAME` environment variables, or `"unknown"` if neither is set
-- **`{{ tt.uid }}` / `{{ tt.gid }}` are POSIX only**: `os.getuid()`/`os.getgid()` don't exist on Windows, so these variables are not defined there — referencing them fails with the usual "built-in variable not defined" error. They exist primarily to pass the host UID/GID as Docker build args; see [Containerised Runners (Docker)](#containerised-runners-docker)
+- **`{{ tt.uid }}` / `{{ tt.gid }}` are POSIX only**: `os.getuid()`/`os.getgid()` don't exist on Windows, so these variables are not defined there — referencing them fails rather than rendering an empty value. In a runner field that surfaces as the usual "built-in variable not defined" error; in a task `cmd` it surfaces as the template engine's undefined-variable error for the task. They exist primarily to pass the host UID/GID as Docker build args; see [Containerised Runners (Docker)](#containerised-runners-docker)
 
 ## File Imports
 

--- a/src/tasktree/README.md
+++ b/src/tasktree/README.md
@@ -582,6 +582,90 @@ TaskTree writes the task `cmd` to a temporary script file and executes `interpre
 - **Unix/macOS**: bash
 - **Windows**: cmd
 
+### Containerised Runners (Docker)
+
+A `type: containerised` runner with `engine: docker` builds an image from a Dockerfile and runs the task inside a container from that image:
+
+```yaml
+runners:
+  build-env:
+    type: containerised
+    engine: docker
+    dockerfile: docker/Dockerfile
+    context: docker              # Build context; defaults to the Dockerfile's directory
+    args:
+      build: ["--build-arg", "VERSION={{ env.VERSION }}"]  # Passed to `docker build`
+      run: ["--memory=2g"]                                  # Passed to `docker run`
+    volumes:
+      - "{{ tt.project_root }}/cache:/cache"
+    ports:
+      - "8080:8080"
+    env_vars:
+      RUST_LOG: debug
+    run_as_root: false           # See "User mapping" below
+
+tasks:
+  build:
+    runner: build-env
+    cmd: cargo build --release
+```
+
+| Field | Meaning |
+|-------|---------|
+| `dockerfile` | Path to the Dockerfile, relative to the project root. |
+| `context` | Build context directory. Defaults to the Dockerfile's parent directory if omitted. |
+| `args.build` | Extra arguments inserted into `docker build` (e.g. `--build-arg`, `--no-cache`). |
+| `args.run` | Extra arguments inserted into `docker run` (e.g. `--memory`, `--network`). |
+| `volumes` | Additional `-v host:container[:ro]` mounts, beyond the automatic project-root mount described below. |
+| `ports` | `-p host:container` port mappings. |
+| `env_vars` | Environment variables injected into the container with `-e`. |
+| `run_as_root` | If `true`, skip user mapping and run as root in the container (see below). Defaults to `false`. |
+
+**Image build and caching.** TaskTree builds each runner's image at most once per invocation, tagged `tt-env-<runner-name>`. Layer caching is entirely Docker's — TaskTree does not track image freshness itself beyond that one-build-per-run behaviour, so a Dockerfile or build-arg change takes effect on the next `docker build` the same way it would from the command line.
+
+**Automatic project-root mount.** Unless a `volumes` entry already covers it, TaskTree automatically mounts the project root into the container at its own resolved path (e.g. `/home/me/project:/home/me/project`), so relative paths in commands, inputs, and outputs behave the same on the host and in the container.
+
+**User mapping and container identity.** By default (`run_as_root: false`), TaskTree runs the container with `--user <host-uid>:<host-gid>` so that files created in mounted volumes end up owned by the host user rather than root. This is a *numeric* UID:GID mapping — Docker does not require that UID to exist in the image's `passwd` database for file ownership to work.
+
+Identity resolution is a different story: if the image has no `passwd` entry for that UID, commands like `id -un`, `whoami`, or anything relying on `$HOME` (`pip`, `npm`, `cargo`, `git config --global`, ...) will fail or misbehave, because `$HOME` falls back to `/`, which the mapped user cannot write to:
+
+```console
+$ docker run --rm --user 501:20 python:3.12-slim sh -c 'id; echo HOME=$HOME'
+uid=501 gid=20(dialout) groups=20(dialout)
+HOME=/
+```
+
+The fix belongs in the image, not in TaskTree: give the Dockerfile a build-arg-driven user creation step, guarded so it's skipped when the base image already ships that UID (e.g. `ubuntu`, `node`, `postgres` images commonly ship UID 1000):
+
+```dockerfile
+ARG UID=1000
+ARG GID=1000
+RUN set -eu; \
+    if ! getent passwd "$UID" >/dev/null; then \
+        getent group "$GID" >/dev/null || groupadd -g "$GID" runner; \
+        useradd -u "$UID" -g "$GID" -m -s /bin/bash runner; \
+    fi
+# Alpine base images: use adduser/addgroup instead of useradd/groupadd:
+#   addgroup -g "$GID" runner 2>/dev/null || true
+#   adduser -u "$UID" -G runner -D -s /bin/sh runner
+```
+
+Wire the host's UID/GID into the build with the `{{ tt.uid }}` / `{{ tt.gid }}` built-in variables (POSIX only — see [Built-in Variables](#built-in-variables)):
+
+```yaml
+runners:
+  build-env:
+    type: containerised
+    engine: docker
+    dockerfile: docker/Dockerfile
+    args:
+      build: ["--build-arg", "UID={{ tt.uid }}", "--build-arg", "GID={{ tt.gid }}"]
+```
+
+Once the image has a matching `passwd` entry, `id`, `whoami`, and `$HOME` all resolve correctly without giving up the ownership guarantee `run_as_root: false` provides. Reach for `run_as_root: true` only if you specifically need the container to run as root — it disables user mapping entirely, so files it creates in mounted volumes end up owned by root on the host.
+
+**Nested invocations.** See [Nested Task Invocations](#nested-task-invocations) for how `tt` inside a container detects and handles Docker-in-Docker (`TT_CONTAINERIZED_RUNNER`).
+
 ### Nix Runners (flake devShells)
 
 A `type: nix` runner executes tasks inside the environment of a [Nix flake](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html) devShell. The devShell provides a pinned, reproducible toolchain; the task itself runs as a normal host process with that toolchain merged into its environment:
@@ -2004,6 +2088,8 @@ Task Tree provides system-provided variables that tasks can reference using `{{ 
 | `{{ tt.timestamp_unix }}` | Unix epoch timestamp when task started | `1703772645` |
 | `{{ tt.user_home }}` | Current user's home directory (cross-platform) | `/home/user` or `C:\Users\user` |
 | `{{ tt.user_name }}` | Current username | `alice` |
+| `{{ tt.uid }}` | Host numeric user ID (POSIX only) | `501` |
+| `{{ tt.gid }}` | Host numeric group ID (POSIX only) | `20` |
 
 ### Usage Examples
 
@@ -2057,6 +2143,7 @@ tasks:
 - **Working directory**: `{{ tt.working_dir }}` reflects the task's `working_dir` setting, or the project root if not specified
 - **Recipe vs Project**: `{{ tt.recipe_dir }}` points to where the recipe file is located, while `{{ tt.project_root }}` points to where the `.tasktree-state` file is (usually the same, but can differ)
 - **Username fallback**: If `os.getlogin()` fails, `{{ tt.user_name }}` falls back to `$USER` or `$USERNAME` environment variables, or `"unknown"` if neither is set
+- **`{{ tt.uid }}` / `{{ tt.gid }}` are POSIX only**: `os.getuid()`/`os.getgid()` don't exist on Windows, so these variables are not defined there — referencing them fails with the usual "built-in variable not defined" error. They exist primarily to pass the host UID/GID as Docker build args; see [Containerised Runners (Docker)](#containerised-runners-docker)
 
 ## File Imports
 

--- a/src/tasktree/docker.py
+++ b/src/tasktree/docker.py
@@ -235,8 +235,12 @@ class DockerManager:
         flags: list[str] = []
 
         # Run as the current host user unless disabled or on Windows, so files
-        # created in mounted volumes are owned by the host user (numeric mapping;
-        # the user need not exist in the container).
+        # created in mounted volumes are owned by the host user. This is a
+        # numeric UID:GID mapping only -- it does not require the UID to exist
+        # in the image's passwd database. Ownership works either way, but
+        # identity does not: without a matching passwd entry, `id`/`whoami`
+        # fail and $HOME falls back to `/`. See {{ tt.uid }} / {{ tt.gid }}
+        # for wiring the host UID into an image build that adds one.
         if not env.run_as_root and self._should_add_user_flag():
             flags.extend(["--user", f"{os.getuid()}:{os.getgid()}"])
 

--- a/src/tasktree/executor.py
+++ b/src/tasktree/executor.py
@@ -268,6 +268,16 @@ class Executor:
             )
         builtin_vars["user_name"] = user_name
 
+        # {{ tt.uid }} / {{ tt.gid }} - Host numeric UID/GID, for matching a
+        # containerised runner's --user mapping to a passwd entry in the image.
+        # Not defined on Windows, where os.getuid()/os.getgid() don't exist;
+        # referencing them there hits the substitution engine's usual
+        # "not defined" error rather than a platform-specific one, since these
+        # keys are collected unconditionally on every task run.
+        if platform.system() != "Windows":
+            builtin_vars["uid"] = str(os.getuid())
+            builtin_vars["gid"] = str(os.getgid())
+
         return builtin_vars
 
     def _collect_builtin_variables(

--- a/src/tasktree/executor.py
+++ b/src/tasktree/executor.py
@@ -255,7 +255,7 @@ class Executor:
             builtin_vars["user_home"] = str(user_home)
         except Exception as e:
             raise ExecutionError(
-                f"Failed to get user home directory for {{ tt.user_home }}: {e}"
+                f"Failed to get user home directory for {{{{ tt.user_home }}}}: {e}"
             )
 
         # {{ tt.user_name }} - Current username (with fallback)

--- a/src/tasktree/lsp/builtin_variables.py
+++ b/src/tasktree/lsp/builtin_variables.py
@@ -11,4 +11,6 @@ BUILTIN_VARIABLES = [
     "timestamp_unix",  # Unix epoch timestamp when task started
     "user_home",  # Current user's home directory (cross-platform)
     "user_name",  # Current username
+    "uid",  # Host numeric user ID (POSIX only)
+    "gid",  # Host numeric group ID (POSIX only)
 ]

--- a/src/tasktree/substitution.py
+++ b/src/tasktree/substitution.py
@@ -260,25 +260,25 @@ def substitute_dependency_args(
 
         if prefix == "var":
             raise ValueError(
-                f"Task '{parent_task_name}': dependency argument contains {{ var.{name} }}\n"
+                f"Task '{parent_task_name}': dependency argument contains {{{{ var.{name} }}}}\n"
                 f"Template: {template_value}\n\n"
-                f"Variables ({{ var.* }}) are not allowed in dependency arguments.\n"
+                f"Variables ({{{{ var.* }}}}) are not allowed in dependency arguments.\n"
                 f"Variables are substituted at parse time, use them directly in task definitions.\n"
-                f"In dependency arguments, only {{ arg.* }} templates are supported."
+                f"In dependency arguments, only {{{{ arg.* }}}} templates are supported."
             )
         elif prefix == "env":
             raise ValueError(
-                f"Task '{parent_task_name}': dependency argument contains {{ env.{name} }}\n"
+                f"Task '{parent_task_name}': dependency argument contains {{{{ env.{name} }}}}\n"
                 f"Template: {template_value}\n\n"
-                f"Environment variables ({{ env.* }}) are not allowed in dependency arguments.\n"
-                f"In dependency arguments, only {{ arg.* }} templates are supported."
+                f"Environment variables ({{{{ env.* }}}}) are not allowed in dependency arguments.\n"
+                f"In dependency arguments, only {{{{ arg.* }}}} templates are supported."
             )
         elif prefix == "tt":
             raise ValueError(
-                f"Task '{parent_task_name}': dependency argument contains {{ tt.{name} }}\n"
+                f"Task '{parent_task_name}': dependency argument contains {{{{ tt.{name} }}}}\n"
                 f"Template: {template_value}\n\n"
-                f"Built-in variables ({{ tt.* }}) are not allowed in dependency arguments.\n"
-                f"In dependency arguments, only {{ arg.* }} templates are supported."
+                f"Built-in variables ({{{{ tt.* }}}}) are not allowed in dependency arguments.\n"
+                f"In dependency arguments, only {{{{ arg.* }}}} templates are supported."
             )
 
     # Substitute {{ arg.* }} using parent's arguments

--- a/src/tasktree/substitution.py
+++ b/src/tasktree/substitution.py
@@ -214,7 +214,7 @@ def substitute_builtin_variables(text: str, builtin_vars: dict[str, str]) -> str
 
         if name not in builtin_vars:
             raise ValueError(
-                f"Built-in variable '{{ tt.{name} }}' is not defined. "
+                f"Built-in variable '{{{{ tt.{name} }}}}' is not defined. "
                 f"Available built-in variables: {', '.join(sorted(builtin_vars.keys()))}"
             )
 

--- a/tasktree.yaml
+++ b/tasktree.yaml
@@ -39,7 +39,8 @@ tasks:
       if [[ "{{ arg.sync | lower }}" != "false" ]]; then
         uv sync --extra dev
       fi
-      PYTHONPATH=tests uv run pytest tests/{{ arg.suite }}
+      # -s: pytest's capture temp file cannot live on a bind-mounted host /tmp
+      PYTHONPATH=tests uv run --extra dev pytest -s tests/{{ arg.suite }}
 
   unit-test:
     desc: "Run unit tests"

--- a/tasktree.yaml
+++ b/tasktree.yaml
@@ -1,22 +1,28 @@
 # yaml-language-server: $schema=schema/tasktree-schema.json
-runners:
+interpreters:
   default: bash-strict
   bash-strict:
-    interpreter:
-      cmd: bash
-      preamble: set -euo pipefail
+    cmd: bash
+    preamble: set -euo pipefail
+
+runners:
   tt-test:
     type: containerised
     engine: docker
     dockerfile: Dockerfile
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - /tmp:/host_tmp
+      # Mounted at the same path on both sides so that temp dirs created by the
+      # e2e tests resolve identically for the host docker daemon we talk to.
+      - /tmp:/tmp
+      # Give the container its own venv, so host and container stop tearing down
+      # and rebuilding each other's .venv on every switch.
+      - .venv-docker:{{ tt.project_root }}/.venv
     args:
       run: ["--group-add", "0"]
     env_vars:
-      HOME: /host_tmp
-      TMPDIR: /host_tmp
+      HOME: /tmp
+      TMPDIR: /tmp
 
 tasks:
   dev-setup:

--- a/tasktree.yaml
+++ b/tasktree.yaml
@@ -117,6 +117,6 @@ tasks:
   clean:
     desc: Remove build artifacts and cache files
     cmd: |
-      rm -rf dist/ build/ *.egg-info .venv
+      rm -rf dist/ build/ *.egg-info .venv .venv-docker
       rm -rf .pytest_cache
       find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true

--- a/tests/e2e/test_lsp_subprocess.py
+++ b/tests/e2e/test_lsp_subprocess.py
@@ -160,8 +160,8 @@ class TestLSPSubprocess(unittest.TestCase):
             self.assertIn("result", completion_response)
             result = completion_response["result"]
 
-            # Should get 8 built-in variables
-            self.assertEqual(len(result["items"]), 8)
+            # Should get 10 built-in variables
+            self.assertEqual(len(result["items"]), 10)
             var_names = {item["label"] for item in result["items"]}
             expected = {
                 "project_root",
@@ -172,6 +172,8 @@ class TestLSPSubprocess(unittest.TestCase):
                 "timestamp_unix",
                 "user_home",
                 "user_name",
+                "uid",
+                "gid",
             }
             self.assertEqual(var_names, expected)
 

--- a/tests/fixtures/builtin_vars_uid_gid/docker/Dockerfile
+++ b/tests/fixtures/builtin_vars_uid_gid/docker/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:latest

--- a/tests/fixtures/builtin_vars_uid_gid/tasktree.yaml
+++ b/tests/fixtures/builtin_vars_uid_gid/tasktree.yaml
@@ -1,0 +1,22 @@
+runners:
+  test-runner:
+    type: containerised
+    engine: docker
+    dockerfile: docker/Dockerfile
+    context: .
+    args:
+      build:
+        - "--build-arg"
+        - "UID={{ tt.uid }}"
+        - "--build-arg"
+        - "GID={{ tt.gid }}"
+
+tasks:
+  test-vars:
+    cmd: |
+      echo "uid={{ tt.uid }}" > {{ tt.project_root }}/output.txt
+      echo "gid={{ tt.gid }}" >> {{ tt.project_root }}/output.txt
+
+  docker-test:
+    runner: test-runner
+    cmd: echo "Testing tt.uid/tt.gid in docker build args"

--- a/tests/fixtures/builtin_vars_uid_gid_runner_field/docker/Dockerfile
+++ b/tests/fixtures/builtin_vars_uid_gid_runner_field/docker/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:latest

--- a/tests/fixtures/builtin_vars_uid_gid_runner_field/tasktree.yaml
+++ b/tests/fixtures/builtin_vars_uid_gid_runner_field/tasktree.yaml
@@ -1,0 +1,13 @@
+runners:
+  test-runner:
+    type: containerised
+    engine: docker
+    dockerfile: docker/Dockerfile
+    context: .
+    volumes:
+      - "/host/cache:/cache/{{ tt.uid }}"
+
+tasks:
+  docker-test:
+    runner: test-runner
+    cmd: echo "Testing tt.uid in a runner field"

--- a/tests/integration/test_builtin_variables.py
+++ b/tests/integration/test_builtin_variables.py
@@ -390,7 +390,8 @@ class TestBuiltinVariables(unittest.TestCase):
 
         executor = Executor(recipe, state, logger_stub, fake_proc_runner_factory)
 
-        with patch("tasktree.process_runner.subprocess.run", side_effect=mock_run):
+        # tasktree.docker is where the intercepted docker inspect/build calls live
+        with patch("tasktree.docker.subprocess.run", side_effect=mock_run):
             executor.execute_task("docker-test", TaskOutputTypes.ALL)
 
         self.assertIsNotNone(

--- a/tests/integration/test_builtin_variables.py
+++ b/tests/integration/test_builtin_variables.py
@@ -1,6 +1,7 @@
 """Integration tests for built-in variables feature."""
 
 import os
+import platform
 import tempfile
 import unittest
 from pathlib import Path
@@ -321,6 +322,84 @@ class TestBuiltinVariables(unittest.TestCase):
             "docker-test",
             "TASK_NAME_VAR should contain the task name",
         )
+
+    @unittest.skipIf(
+        platform.system() == "Windows", "tt.uid/tt.gid are not defined on Windows"
+    )
+    def test_uid_and_gid_in_task_command(self):
+        """
+        Test that tt.uid/tt.gid substitute to the host's numeric UID/GID in a task command.
+        """
+
+        copy_fixture_files("builtin_vars_uid_gid", Path(self.test_dir))
+
+        recipe = parse_recipe(self.recipe_file)
+        state = StateManager(recipe.project_root)
+        state.load()
+        executor = Executor(recipe, state, logger_stub, make_process_runner)
+        executor.execute_task("test-vars", TaskOutputTypes.ALL)
+
+        output = (Path(self.test_dir) / "output.txt").read_text()
+        lines = {
+            line.split("=", 1)[0]: line.split("=", 1)[1]
+            for line in output.strip().split("\n")
+        }
+
+        self.assertEqual(lines["uid"], str(os.getuid()))
+        self.assertEqual(lines["gid"], str(os.getgid()))
+
+    @unittest.skipIf(
+        platform.system() == "Windows", "tt.uid/tt.gid are not defined on Windows"
+    )
+    def test_uid_and_gid_in_runner_build_args(self):
+        """
+        Test that tt.uid/tt.gid substitute into a containerised runner's args.build,
+        the build-arg wiring used to give a container image a passwd entry matching
+        the host's mapped UID.
+        """
+
+        from unittest.mock import patch, Mock
+
+        copy_fixture_files("builtin_vars_uid_gid", Path(self.test_dir))
+
+        recipe = parse_recipe(self.recipe_file)
+        state = StateManager(recipe.project_root)
+        state.load()
+
+        docker_build_command = None
+
+        def mock_run(*args, **kwargs):
+            nonlocal docker_build_command
+            cmd = args[0] if args else kwargs.get("args", [])
+            if isinstance(cmd, list) and "build" in cmd:
+                docker_build_command = cmd
+            if isinstance(cmd, list) and "inspect" in cmd:
+                result = Mock()
+                result.stdout = "sha256:test123\\n"
+                result.returncode = 0
+                return result
+            result = Mock()
+            result.returncode = 0
+            return result
+
+        process_runner_spy = MagicMock(spec=ProcessRunner)
+        process_runner_spy.run.side_effect = mock_run
+
+        fake_proc_runner_factory = MagicMock()
+        fake_proc_runner_factory.return_value = process_runner_spy
+
+        executor = Executor(recipe, state, logger_stub, fake_proc_runner_factory)
+
+        with patch("tasktree.process_runner.subprocess.run", side_effect=mock_run):
+            executor.execute_task("docker-test", TaskOutputTypes.ALL)
+
+        self.assertIsNotNone(
+            docker_build_command, "Docker build command should have been captured"
+        )
+        self.assertIn(f"UID={os.getuid()}", docker_build_command)
+        self.assertIn(f"GID={os.getgid()}", docker_build_command)
+        for arg in docker_build_command:
+            self.assertNotIn("{{ tt.", arg)
 
     def test_env_vars_in_runner_fields(self):
         """

--- a/tests/integration/test_builtin_variables.py
+++ b/tests/integration/test_builtin_variables.py
@@ -397,9 +397,10 @@ class TestBuiltinVariables(unittest.TestCase):
             with self.assertRaises(ValueError) as cm:
                 executor.execute_task("docker-test", TaskOutputTypes.ALL)
 
-        # NB: the message renders single braces - the f-string that builds it
-        # escapes '{{' down to '{'. Asserting the text as emitted, not as intended.
-        self.assertIn("Built-in variable '{ tt.uid }' is not defined", str(cm.exception))
+        # The message quotes the placeholder in the template syntax the user wrote
+        self.assertIn(
+            "Built-in variable '{{ tt.uid }}' is not defined", str(cm.exception)
+        )
         self.assertNotIn("uid", str(cm.exception).split("Available")[1])
 
     @unittest.skipIf(

--- a/tests/integration/test_builtin_variables.py
+++ b/tests/integration/test_builtin_variables.py
@@ -348,6 +348,60 @@ class TestBuiltinVariables(unittest.TestCase):
         self.assertEqual(lines["uid"], str(os.getuid()))
         self.assertEqual(lines["gid"], str(os.getgid()))
 
+    def test_uid_in_task_command_is_undefined_on_windows(self):
+        """
+        Test that a task command referencing tt.uid on Windows fails loudly
+        rather than rendering an empty value. This is the end-user side of the
+        omission documented in src/tasktree/README.md.
+
+        Task commands render through the template engine, so the failure names
+        the undefined attribute and the task, not the substitution engine's
+        "Built-in variable ... is not defined" message - that one belongs to the
+        runner-field path (see test_uid_in_runner_volume_is_undefined_on_windows).
+        """
+
+        from unittest.mock import patch
+
+        copy_fixture_files("builtin_vars_uid_gid", Path(self.test_dir))
+
+        recipe = parse_recipe(self.recipe_file)
+        state = StateManager(recipe.project_root)
+        state.load()
+        executor = Executor(recipe, state, logger_stub, make_process_runner)
+
+        with patch("tasktree.executor.platform.system", return_value="Windows"):
+            with self.assertRaises(ValueError) as cm:
+                executor.execute_task("test-vars", TaskOutputTypes.ALL)
+
+        self.assertIn("Undefined variable in task 'test-vars'", str(cm.exception))
+        self.assertIn("uid", str(cm.exception))
+        self.assertFalse((Path(self.test_dir) / "output.txt").exists())
+
+    def test_uid_in_runner_volume_is_undefined_on_windows(self):
+        """
+        Test that tt.uid in a runner field on Windows raises the substitution
+        engine's "Built-in variable ... is not defined" error, which is the
+        error src/tasktree/README.md documents for the omitted variables.
+        """
+
+        from unittest.mock import patch
+
+        copy_fixture_files("builtin_vars_uid_gid_runner_field", Path(self.test_dir))
+
+        recipe = parse_recipe(self.recipe_file)
+        state = StateManager(recipe.project_root)
+        state.load()
+        executor = Executor(recipe, state, logger_stub, make_process_runner)
+
+        with patch("tasktree.executor.platform.system", return_value="Windows"):
+            with self.assertRaises(ValueError) as cm:
+                executor.execute_task("docker-test", TaskOutputTypes.ALL)
+
+        # NB: the message renders single braces - the f-string that builds it
+        # escapes '{{' down to '{'. Asserting the text as emitted, not as intended.
+        self.assertIn("Built-in variable '{ tt.uid }' is not defined", str(cm.exception))
+        self.assertNotIn("uid", str(cm.exception).split("Available")[1])
+
     @unittest.skipIf(
         platform.system() == "Windows", "tt.uid/tt.gid are not defined on Windows"
     )

--- a/tests/integration/test_lsp_completion.py
+++ b/tests/integration/test_lsp_completion.py
@@ -58,7 +58,7 @@ class TestLSPCompletionIntegration(unittest.TestCase):
         result = completion_handler(completion_params)
 
         # Verify completions
-        self.assertEqual(len(result.items), 8)
+        self.assertEqual(len(result.items), 10)
         var_names = {item.label for item in result.items}
         expected = {
             "project_root",
@@ -69,6 +69,8 @@ class TestLSPCompletionIntegration(unittest.TestCase):
             "timestamp_unix",
             "user_home",
             "user_name",
+            "uid",
+            "gid",
         }
         self.assertEqual(var_names, expected)
 

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -5,6 +5,7 @@ import platform
 import tempfile
 import time
 import unittest
+from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch, call
@@ -1506,6 +1507,61 @@ class TestExecutorPrivateMethods(unittest.TestCase):
             changed = executor._check_inputs_changed(task, cached_state, ["bin/*"])
 
             self.assertIn("bin/exe1", changed)
+
+
+class TestUidGidBuiltinVariables(unittest.TestCase):
+    """
+    Tests for the {{ tt.uid }} / {{ tt.gid }} built-in variables.
+    """
+
+    def _make_executor(self, project_root):
+        tasks = {"test": Task(name="test", cmd="echo hi")}
+        recipe = Recipe(
+            tasks=tasks,
+            project_root=project_root,
+            recipe_path=project_root / "tasktree.yaml",
+        )
+        state_manager = StateManager(project_root)
+        return Executor(recipe, state_manager, logger_stub, make_process_runner)
+
+    @unittest.skipIf(
+        platform.system() == "Windows", "os.getuid/os.getgid do not exist on Windows"
+    )
+    def test_uid_and_gid_render_host_values(self):
+        """
+        Test that tt.uid/tt.gid render the host's numeric UID/GID on POSIX.
+        """
+
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            executor = self._make_executor(project_root)
+            task = executor.recipe.tasks["test"]
+
+            builtin_vars = executor._collect_early_builtin_variables(
+                task, datetime.now(timezone.utc)
+            )
+
+            self.assertEqual(builtin_vars["uid"], str(os.getuid()))
+            self.assertEqual(builtin_vars["gid"], str(os.getgid()))
+
+    def test_uid_and_gid_omitted_on_windows(self):
+        """
+        Test that tt.uid/tt.gid are omitted on Windows (where os.getuid/os.getgid
+        don't exist), rather than raising or rendering an empty value.
+        """
+
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir)
+            executor = self._make_executor(project_root)
+            task = executor.recipe.tasks["test"]
+
+            with patch("tasktree.executor.platform.system", return_value="Windows"):
+                builtin_vars = executor._collect_early_builtin_variables(
+                    task, datetime.now(timezone.utc)
+                )
+
+            self.assertNotIn("uid", builtin_vars)
+            self.assertNotIn("gid", builtin_vars)
 
 
 class TestOnlyMode(unittest.TestCase):

--- a/tests/unit/test_lsp_builtin_variables.py
+++ b/tests/unit/test_lsp_builtin_variables.py
@@ -22,12 +22,14 @@ class TestBuiltinVariables(unittest.TestCase):
             "timestamp_unix",
             "user_home",
             "user_name",
+            "uid",
+            "gid",
         ]
         self.assertEqual(set(BUILTIN_VARIABLES), set(expected))
 
     def test_builtin_variables_count(self):
-        """Test that we have exactly 8 built-in variables."""
-        self.assertEqual(len(BUILTIN_VARIABLES), 8)
+        """Test that we have exactly 10 built-in variables."""
+        self.assertEqual(len(BUILTIN_VARIABLES), 10)
 
     def test_builtin_variables_are_strings(self):
         """Test that all built-in variables are strings."""

--- a/tests/unit/test_lsp_server.py
+++ b/tests/unit/test_lsp_server.py
@@ -271,7 +271,7 @@ class TestCreateServer(unittest.TestCase):
         result = completion_handler(completion_params)
 
         # Verify we get all 8 built-in variables
-        self.assertEqual(len(result.items), 8)
+        self.assertEqual(len(result.items), 10)
         var_names = {item.label for item in result.items}
         expected_vars = {
             "project_root",
@@ -282,6 +282,8 @@ class TestCreateServer(unittest.TestCase):
             "timestamp_unix",
             "user_home",
             "user_name",
+            "uid",
+            "gid"
         }
         self.assertEqual(var_names, expected_vars)
 


### PR DESCRIPTION
## Summary

- Add tt.uid and tt.gid builtin variables (host numeric UID/GID, POSIX only) so a containerised runner's Dockerfile can add a passwd entry matching the mapped host UID via a build arg
- Fix the misleading docker.py comment on the --user flag (ownership vs identity), which was the root cause behind the issue
- Add unit and integration tests for the new variables, including propagation into task commands and runner args.build
- Keep the LSP tt.* completion list and CLAUDE.md builtin variable references in sync (8 to 10 variables)
- Document containerised Docker runners in the user guide (src/tasktree/README.md): field reference, image build and caching, the automatic project-root mount, and the UID-mapping identity gotcha with the getent-guarded Dockerfile fix
- Remove the not-ready-for-release advisory from the dev README Docker Integration section, and correct a stale detail (state file reached via the auto-mounted project root, not a dedicated mount)

Item 3 from the issue (the optional HOME fallback) remains deferred, as agreed in the plan discussion.

Ref: #215

Generated with [Claude Code](https://claude.ai/code)